### PR TITLE
feat: Add ASP.NET trace scanner

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -64,6 +64,9 @@ scanners:
     test_uuid_ids: true
     test_encoded_ids: true
 
+  trace:
+    enabled: true
+
 # Reconnaissance configurations
 recon:
   subdomain_enum:

--- a/core/scanner_controller.py
+++ b/core/scanner_controller.py
@@ -21,6 +21,7 @@ from scanners.ssrf.ssrf_scanner import SSRFScanner
 from scanners.xxe.xxe_scanner import XXEScanner
 from scanners.cmdi.command_injection_scanner import CommandInjectionScanner
 from scanners.idor.idor_scanner import IDORScanner
+from scanners.trace.trace_scanner import TraceScanner
 
 logger = logging.getLogger(__name__)
 security_logger = get_security_logger()
@@ -51,6 +52,7 @@ class ScannerController:
             'xxe': XXEScanner(config_manager),
             'cmdi': CommandInjectionScanner(config_manager),
             'idor': IDORScanner(config_manager),
+            'trace': TraceScanner(config_manager),
         }
     
     def run_scan(self, scan_type: str) -> ScanResults:

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ For more information, see the documentation in the docs/ directory.
     # Main action groups
     action_group = parser.add_mutually_exclusive_group(required=True)
     action_group.add_argument("--scan", choices=[
-        "sqli", "xss", "csrf", "auth", "traversal", "ssrf", "xxe", "cmdi", "idor", "all"
+        "sqli", "xss", "csrf", "auth", "traversal", "ssrf", "xxe", "cmdi", "idor", "trace", "all"
     ], help="Run vulnerability scanners")
     action_group.add_argument("--recon", choices=[
         "subdomain", "portscan", "fingerprint", "urls", "all"

--- a/scanners/trace/trace_scanner.py
+++ b/scanners/trace/trace_scanner.py
@@ -1,0 +1,68 @@
+"""
+ASP.NET Trace Scanner - Detects if ASP.NET tracing is enabled
+"""
+
+import logging
+import requests
+from urllib.parse import urljoin
+from typing import List
+from core.config.config_manager import ConfigManager
+from core.reporting.report_generator import Finding, Severity
+from core.utils.logger import get_security_logger
+
+logger = logging.getLogger(__name__)
+security_logger = get_security_logger()
+
+class TraceScanner:
+    """ASP.NET Tracing vulnerability scanner."""
+
+    def __init__(self, config_manager: ConfigManager):
+        """
+        Initialize the ASP.NET Trace scanner.
+
+        Args:
+            config_manager: Configuration manager instance
+        """
+        self.config = config_manager.get_scanner_config('trace')
+        self.general_config = config_manager.get('general')
+
+    def scan(self, target: str) -> List[Finding]:
+        """
+        Scan target for ASP.NET tracing.
+
+        Args:
+            target: Target URL to scan
+
+        Returns:
+            List of findings
+        """
+        logger.info(f"Starting ASP.NET Trace scan on {target}")
+        findings = []
+
+        trace_url = urljoin(target, "trace.axd")
+
+        try:
+            response = requests.get(trace_url, timeout=self.general_config.get('timeout', 10), verify=False, allow_redirects=False)
+
+            if response.status_code == 200 and "Application Trace" in response.text:
+                finding = Finding(
+                    title="ASP.NET Tracing Enabled",
+                    severity=Severity.MEDIUM,
+                    confidence=0.9,
+                    description="ASP.NET tracing is enabled and accessible. This can expose sensitive information about the application, such as session IDs, physical paths, and other debugging details.",
+                    target=trace_url,
+                    vulnerability_type="Configuration",
+                    evidence=f"The trace.axd page is accessible and returned a 200 OK status code. The response contains the text 'Application Trace'.",
+                    impact="An attacker can use the information exposed by trace.axd to gain a deeper understanding of the application, which can aid in further attacks. The exposed information can include sensitive data.",
+                    remediation="Disable ASP.NET tracing in the Web.config file by setting <trace enabled=\"false\" /> within the <system.web> section.",
+                    references=["https://portswigger.net/kb/issues/00100280_asp-net-tracing-enabled"]
+                )
+                findings.append(finding)
+                security_logger.log_vulnerability_found("ASPNET_TRACE_ENABLED", trace_url, "MEDIUM", 0.9)
+                logger.warning(f"ASP.NET Tracing is enabled at {trace_url}")
+
+        except requests.exceptions.RequestException as e:
+            logger.debug(f"ASP.NET Trace scan failed for {trace_url}: {str(e)}")
+
+        logger.info(f"ASP.NET Trace scan completed - {len(findings)} findings")
+        return findings


### PR DESCRIPTION
This commit introduces a new scanner to detect if ASP.NET tracing is enabled. The scanner checks for the presence of `trace.axd` and reports a vulnerability if it is found and accessible.

The new scanner is integrated into the scanner controller and can be run using the `--scan trace` command-line option.